### PR TITLE
add some aria-labels for a11y

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,15 +32,15 @@
       </a>
 
       <div class="trigger">
-        
-          
-        
-          
-        
-          
-        
-          
-        
+
+
+
+
+
+
+
+
+
       </div>
     </nav>
 
@@ -67,15 +67,15 @@
     <div class="footer-col-wrapper">
       <div class="footer-col  footer-col-1">
         <ul class="contact-list">
-          <li><a href="mailto:kamal@marhubi.com">kamal@marhubi.com</a></li>
+          <li><a href="mailto:kamal@marhubi.com" aria-label="Send me an email">kamal@marhubi.com</a></li>
         </ul>
       </div>
 
       <div class="footer-col  footer-col-2">
         <ul class="social-media-list">
-          
+
           <li>
-            <a href="https://github.com/kamalmarhubi">
+            <a href="https://github.com/kamalmarhubi" aria-label="Follow me on GitHub">
               <span class="icon  icon--github">
                 <svg viewBox="0 0 16 16">
                   <path fill="#828282" d="M7.999,0.431c-4.285,0-7.76,3.474-7.76,7.761 c0,3.428,2.223,6.337,5.307,7.363c0.388,0.071,0.53-0.168,0.53-0.374c0-0.184-0.007-0.672-0.01-1.32 c-2.159,0.469-2.614-1.04-2.614-1.04c-0.353-0.896-0.862-1.135-0.862-1.135c-0.705-0.481,0.053-0.472,0.053-0.472 c0.779,0.055,1.189,0.8,1.189,0.8c0.692,1.186,1.816,0.843,2.258,0.645c0.071-0.502,0.271-0.843,0.493-1.037 C4.86,11.425,3.049,10.76,3.049,7.786c0-0.847,0.302-1.54,0.799-2.082C3.768,5.507,3.501,4.718,3.924,3.65 c0,0,0.652-0.209,2.134,0.796C6.677,4.273,7.34,4.187,8,4.184c0.659,0.003,1.323,0.089,1.943,0.261 c1.482-1.004,2.132-0.796,2.132-0.796c0.423,1.068,0.157,1.857,0.077,2.054c0.497,0.542,0.798,1.235,0.798,2.082 c0,2.981-1.814,3.637-3.543,3.829c0.279,0.24,0.527,0.713,0.527,1.437c0,1.037-0.01,1.874-0.01,2.129 c0,0.208,0.14,0.449,0.534,0.373c3.081-1.028,5.302-3.935,5.302-7.362C15.76,3.906,12.285,0.431,7.999,0.431z"/>
@@ -85,11 +85,11 @@
               <span class="username">kamalmarhubi</span>
             </a>
           </li>
-          
 
-          
+
+
           <li>
-            <a href="https://twitter.com/kamalmarhubi">
+            <a href="https://twitter.com/kamalmarhubi" aria-label="Follow me on Twitter">
               <span class="icon  icon--twitter">
                 <svg viewBox="0 0 16 16">
                   <path fill="#828282" d="M15.969,3.058c-0.586,0.26-1.217,0.436-1.878,0.515c0.675-0.405,1.194-1.045,1.438-1.809
@@ -100,7 +100,7 @@
               <span class="username">kamalmarhubi</span>
             </a>
           </li>
-          
+
         </ul>
       </div>
 


### PR DESCRIPTION
You totally don't have to merge this if you don't want to (and you can close it and use different aria labels), but I just noticed your icon links are unlabelled, so they both read your name, but not what they're there for.

Before (with VoiceOver on Mac):
<img width="262" alt="screen shot 2016-05-24 at 11 03 11 pm" src="https://cloud.githubusercontent.com/assets/1369170/15529683/dbbf72f8-2203-11e6-959e-fccd3904b244.png">

After:
<img width="294" alt="screen shot 2016-05-24 at 11 03 58 pm" src="https://cloud.githubusercontent.com/assets/1369170/15529688/e12638b2-2203-11e6-8809-3e789a6a332b.png">

I have abstained from fixing the indentation or extra spacing in your html :)
